### PR TITLE
fix: variables passed using --env are not being set as environment variables

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -75,6 +75,13 @@ func (r *GinkgoRunner) Run(execution testkube.Execution) (result testkube.Execut
 			execution.Content.Repository.Token = r.Params.GitToken
 		}
 	}
+	
+	// convert executor env variables to os env variables
+	for key, value := range execution.Envs {
+		if err = os.Setenv(key, value); err != nil {
+			return result, fmt.Errorf("setting env var: %w", err)
+		}
+	}
 
 	// use `execution.Variables` for variables passed from Test/Execution
 	// variables of type "secret" will be automatically decoded


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- execution.Envs are now exported as environment variables to be used by the runner